### PR TITLE
Deploy deal ingester on daily basis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,14 @@
-name: CI
+name: CI/CD
 on:
+  # CI triggers
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  # Deployment triggers
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * *' # Run every day at 7am UTC
 
 jobs:
   lint-scripts:
@@ -36,7 +41,8 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   deploy:
-    if: github.ref == 'refs/heads/main'
+    # Only run on cron schedule or manual dispatch
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     needs: [lint-scripts, build-ingester]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: CI
 on:
   # CI triggers
   push:


### PR DESCRIPTION
Deploy deal ingester only once a day or on when manually triggered. Deployment job is triggered every day at 7AM UTC which gives us enough time to monitor the logs in case something fails. 