### PR TITLE
Change dependabot schedule to run daily at 19:00 UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "09:00"
+      time: "19:00"
       timezone: "Europe/Berlin"
     commit-message:
       prefix: "cargo deps"
@@ -13,7 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "09:00"
+      time: "19:00"
       timezone: "Europe/Berlin"
     commit-message:
       prefix: "npm deps"
@@ -22,7 +22,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "09:00"
+      time: "19:00"
       timezone: "Europe/Berlin"
     commit-message:
       prefix: "ci"
@@ -31,6 +31,5 @@ updates:
       - "/"
     schedule:
       interval: "daily"
-      time: "15:00"
+      time: "19:00"
       timezone: "Europe/Berlin"
-


### PR DESCRIPTION
Change dependabot schedule to run daily at 19:00 UTC in order to avoid interrupting deal ingestions in progress. 