### PR TITLE
feat: skip Label=bafkqaaa

### DIFF
--- a/scripts/parse-retrievable-deals.js
+++ b/scripts/parse-retrievable-deals.js
@@ -119,6 +119,11 @@ function * processDeal (deal) {
   assert.strictEqual(typeof Label, 'string', `Label is not a string: ${JSON.stringify(deal.Proposal)}`)
   if (!Label || !Label.match(/^(bafy|bafk|Qm)/)) return
 
+  // bafkqaaa is a CID for an empty file
+  // Spark retrieval check always fails because https://cid.contact/cid/bafkqaaa returns an error.
+  // We agreed to remove deals with that Label from the list of eligible deals
+  if (Label === 'bafkqaaa') return
+
   assert.strictEqual(typeof Provider, 'string', `Provider is not a string: ${JSON.stringify(deal.Proposal)}`)
   assert.strictEqual(typeof PieceCID['/'], 'string', `PieceCID is not a CID link: ${JSON.stringify(deal.Proposal)}`)
   const entry = {


### PR DESCRIPTION
`bafkqaaa` is a CID for an empty file. Spark retrieval check always fails because https://cid.contact/cid/bafkqaaa returns an error.

See https://cid.ipfs.tech/#bafkqaaa
<img width="607" alt="Screenshot 2025-03-14 at 15 38 40" src="https://github.com/user-attachments/assets/e908cb40-ac00-4c03-96a0-4dba5fed0105" />

We agreed to remove deals with that Label from the list of eligible deals.

See https://space-meridian.slack.com/archives/C076S55SPTN/p1741944698622919

Reminder: Delete existing eligible deals `WHERE payload_cid="bafkqaaa"` the next day after landing this pull request.