### PR TITLE
Fix parsing snapshot file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,14 +26,11 @@ fn main() -> Result<()> {
 
     ensure!(start_event == JsonEvent::StartObject);
 
-    // File being read is a snapshot of the JSON-RPC
-    // response containing market deals.
+    // File being read is a snapshot of the JSON-RPC response
+    // containing market deals inside the "result object".
     //
-    // These market deals are found in the "result" object.
-    //
-    // We need to skip all object keys ("id", "jsonrpc", etc)
-    // and their respective values until we find
-    // the "result" key after which the result object starts.
+    // We need to skip all object keys and their values
+    // until we find the "result" key and start of the "result" object.
     log::debug!("looking for 'result' object");
     loop {
         match reader.parse_next()? {


### PR DESCRIPTION
Due to recent change in the snapshot format we're unable to ingest new deals. This PR aims to fix parsing the snapshot file with new format in order to enable ingesting new deals. 

New snapshot format is a JSON-RPC response:

```json
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": {
        "159155": {
            "Proposal": {
                "PieceCID": {
                    "/": "baga6ea4seaqaazz4brpn3zde6dkorq3muck42qzw5hetx7wtwm6oyz4lqdklcpa"
                },
                "PieceSize": 65536,
                "VerifiedDeal": false,
                "Client": "f020319",
                "Provider": "f016305",
                "Label": "mAXESINiz1A6zzmVo8QoU7wKbP+gB3PGSyA43a4ZukzHIxc3z",
                "StartEpoch": 1281643200,
                "EndEpoch": 1282165340,
                "StoragePricePerEpoch": "0",
                "ProviderCollateral": "0",
                "ClientCollateral": "0"
            },
            "State": {
                "SectorNumber": 0,
                "SectorStartEpoch": -1,
                "LastUpdatedEpoch": -1,
                "SlashEpoch": -1
            }
        }
}
```