### PR TITLE
fix: Pin flyctl to 0.3.159

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl machine update ${{ secrets.FLY_MACHINE_ID }} --dockerfile Dockerfile --app ${{ vars.FLY_APP }} -y
+        with:
+          version: 0.3.159
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       - if: failure()


### PR DESCRIPTION
Current `flyctl` binary seems to be broken. This PR pins `flyctl` binary version to older version.